### PR TITLE
Link apartment lobby floors for CFO navigation

### DIFF
--- a/scenes/areas/aptlobby.tscn
+++ b/scenes/areas/aptlobby.tscn
@@ -676,6 +676,10 @@ transform = Transform3D(-1.49026e-08, 0, -1.61244, 0, 0.5, 0, 0.340931, 0, -7.04
 use_collision = true
 size = Vector3(1, 0.3, 1)
 
+[node name="StairsLink" type="NavigationLink3D" parent="."]
+start_position = Vector3(1.54967, 4.41445, -4.5008)
+end_position = Vector3(-0.531735, 0.741105, 8.61442)
+
 [node name="Apt_Door" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.54967, 4.41445, -4.5008)
 


### PR DESCRIPTION
## Summary
- add a NavigationLink3D connecting the second-floor landing and first-floor lobby so navigation spans the stairs

## Testing
- `godot --version` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd2a0b5dc83329f87afc751159cca